### PR TITLE
Fixes showNoteNames parameter not working

### DIFF
--- a/pianoroll/src/main/java/com/citizenwarwick/pianoroll/PianoRoll.kt
+++ b/pianoroll/src/main/java/com/citizenwarwick/pianoroll/PianoRoll.kt
@@ -77,11 +77,13 @@ fun PianoRoll(
                     .clickable { onKeyPressed(note) },
                 contentAlignment = Alignment.BottomCenter
             ) {
-                Text(
-                    fontSize = options.fontSizeScaled.sp,
-                    color = if (isBlackNote) options.blackKeyTextColor else options.whiteKeyTextColor,
-                    text = "${note.pitch.noteName}${note.octave}"
-                )
+                if (options.showNoteNames) {
+                    Text(
+                        fontSize = options.fontSizeScaled.sp,
+                        color = if (isBlackNote) options.blackKeyTextColor else options.whiteKeyTextColor,
+                        text = "${note.pitch.noteName}${note.octave}"
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
It wasn't possible to hide note names because the parameter `showNoteNames` was not being used inside the composable.